### PR TITLE
Support transparent serialisation of datetimes at the expense of anyjson

### DIFF
--- a/rawes/encoders.py
+++ b/rawes/encoders.py
@@ -1,0 +1,10 @@
+import datetime
+from dateutil import tz
+
+def encode_datetime(obj):
+    """
+    ISO encode datetimes
+    """
+    if isinstance(obj, datetime.datetime):
+        return obj.astimezone(tz.tzutc()).strftime('%Y-%m-%dT%H:%M:%SZ')
+    raise TypeError(repr(obj) + " is not JSON serializable")

--- a/rawes/http_connection.py
+++ b/rawes/http_connection.py
@@ -15,7 +15,8 @@
 #
 
 import requests
-import anyjson as json
+import json
+from rawes.encoders import encode_datetime
 
 
 class HttpConnection(object):
@@ -45,7 +46,7 @@ class HttpConnection(object):
 
     def request(self, method, path, **kwargs):
         if 'data' in kwargs and type(kwargs['data']) == dict:
-            kwargs['data'] = json.dumps(kwargs['data'])
+            kwargs['data'] = json.dumps(kwargs['data'], default=encode_datetime)
         response = self.session.request(method, '%s/%s' % (self.url, path), **kwargs)
         return self._decode(response)
 

--- a/rawes/http_connection.py
+++ b/rawes/http_connection.py
@@ -21,6 +21,7 @@ except ImportError:
 
 from rawes.encoders import encode_datetime
 
+import requests
 
 class HttpConnection(object):
     """docstring for HttpConnection"""

--- a/rawes/http_connection.py
+++ b/rawes/http_connection.py
@@ -14,8 +14,11 @@
 #   limitations under the License.
 #
 
-import requests
-import json
+try:
+    import simplejson as json
+except ImportError:
+    import json
+
 from rawes.encoders import encode_datetime
 
 

--- a/rawes/thrift_connection.py
+++ b/rawes/thrift_connection.py
@@ -14,7 +14,8 @@
 #   limitations under the License.
 #
 
-import anyjson as json
+import json
+from rawes.encoders import encode_datetime
 
 try:
     from thrift import Thrift
@@ -67,7 +68,7 @@ class ThriftConnection(object):
         if 'data' in kwargs:
             body = kwargs['data']
             if type(kwargs['data']) == dict:
-                body = json.dumps(kwargs['data'])
+                body = json.dumps(kwargs['data'], default=encode_datetime)
             thriftargs['body'] = body
 
         if 'params' in kwargs:

--- a/rawes/thrift_connection.py
+++ b/rawes/thrift_connection.py
@@ -14,7 +14,11 @@
 #   limitations under the License.
 #
 
-import json
+try:
+    import simplejson as json
+except ImportError:
+    import json
+
 from rawes.encoders import encode_datetime
 
 try:

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ README = open(os.path.join(here, "README.md")).read()
 CHANGES = open(os.path.join(here, "CHANGES.md")).read()
 
 install_requires = [
-    'requests==0.13.9',
+    'requests==0.14.2',
     'thrift==0.8.0',
     'python-dateutil==2.1'
 ]

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ CHANGES = open(os.path.join(here, "CHANGES.md")).read()
 install_requires = [
     'requests==0.13.9',
     'thrift==0.8.0',
-    'anyjson==0.3.3'
+    'python-dateutil==2.1'
 ]
 
 classifiers = [


### PR DESCRIPTION
Hello,

I'm not sure if you're interested in this, but I thought I'd offer it as it was useful to me.

I needed to serialise datetimes, but to do this you must pass an encoder function to the JSON implementation using the "default" keyword. Unfortunately this isn't supported by anyjson. 

Given that since 2.6 simplejson is in the standard library (import json), it seems that the need for anyjson is less than it once was. I included a "try: import simplejson as json except: import json" so that people can still get faster JSON, if they need it [1]. 

[1] I read that current simplejson is as fast as cjson, and both are faster than the older simplejson in stdlib.

cheers

rich
