### PR TITLE
Add a check for thrift_installed when trying to define method_mappings in ThriftConnection

### DIFF
--- a/rawes/thrift_connection.py
+++ b/rawes/thrift_connection.py
@@ -55,7 +55,7 @@ class ThriftConnection(object):
         'put' : Method.PUT,
         'delete' : Method.DELETE,
         'head' : Method.HEAD
-    }
+    } if thrift_installed else {}
 
     def request(self, method, path, **kwargs):
         thriftargs = {}


### PR DESCRIPTION
...so that rawes can work without Thrift support.

When Thrift is not available, the import of Method fails, which means that the attributes used to define the method_mappings dictionary are not available.  Since attempting to instantiate a ThriftConnection object while thrift_installed is True will raise an exception, having this dictionary empty in those cases should be completely safe.
