### PR TITLE
exclude tests from package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,5 +53,5 @@ setup(name='rawes',
       zip_safe=False,
       classifiers=classifiers,
       install_requires=install_requires,
-      packages=find_packages()
+      packages=find_packages(exclude=["tests*"])
       )


### PR DESCRIPTION
The current setup.py results in the installation of a top level tests package 
